### PR TITLE
過去に受け取っていたリプライを読み込むと反応してしまう場合があった

### DIFF
--- a/stream_command.rb
+++ b/stream_command.rb
@@ -49,7 +49,8 @@ Plugin.create(:stream_command) do
 
   on_appear do |msgs|
     reply_pattern = /^@#{Service.primary.idname} ([a-z_]+) (.+)$/
-    msgs.select { |msg| msg.body =~ reply_pattern }
+    msgs.select { |msg| msg.created > defined_time  }
+        .select { |msg| msg.body =~ reply_pattern }
         .each { |msg|
           msg.body =~ reply_pattern
           cmd = $1.to_sym


### PR DESCRIPTION
restプラグインをロードしている場合や、フォロイーがリツイートした場合など、過去のコマンドツイートがappearイベントに渡されるようなことがあった場合、それに反応してしまっていたので、起動後に受け取ったツイートにのみ反応するようにした。